### PR TITLE
refresh cache after install. fixes #2

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -67,7 +67,7 @@ class admin_plugin_pagepacks extends DokuWiki_Admin_Plugin
     }
 
     /**
-     * @param $pack
+     * @param string $pack
      * @throws \splitbrain\PHPArchive\ArchiveIOException
      */
     protected function installPack($pack)
@@ -88,6 +88,10 @@ class admin_plugin_pagepacks extends DokuWiki_Admin_Plugin
         $zip->open($file);
         $zip->extract($target);
         $zip->close();
+
+        // refresh cache
+        // FIXME, it would be better to update the timestamps of the extracted files, but that's currently not possible
+        @touch(DOKU_CONF . 'local.php');
     }
 
     /**


### PR DESCRIPTION
Ideally all the files would be extracted with the current timestamp. To
do so, we would need a callback on all the extracted files. Such a
callback exists in the upstream library already [1], but it's not
available in DokuWiki, yet.

[1] https://github.com/splitbrain/php-archive/blob/10d89013572ba1f4d4ad7fcb74860242f4c3860b/src/Archive.php#L124-L134